### PR TITLE
move asynciterator to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@babel/plugin-transform-async-to-generator": "^7.1.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
-    "asynciterator": "^1.1.1",
     "babel-loader": "^8.0.2",
     "benchmark": "^2.1.3",
     "fs-extra": "^7.0.0",
@@ -53,6 +52,7 @@
   },
   "dependencies": {
     "@rdfjs/data-model": "^1.1.0",
+    "asynciterator": "^1.1.1",
     "debug": "^3.1.0",
     "encoding-down": "^5.0.4",
     "levelup": "^3.1.1",


### PR DESCRIPTION
I've got error: `Error: Cannot find module 'asynciterator'` after installing `quadstore` from npm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/beautifulinteractions/node-quadstore/67)
<!-- Reviewable:end -->
