### PR TITLE
Optional IRI compaction in storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,8 +406,7 @@ implements the `Source`, `Sink` and `Store` interfaces. Additionally, the
 
 Instantiates a new store. The `RdfStore` class extends `QuadStore` and requires
 an instance of a leveldb backend as the `opts.backend` argument. In 
-addition to all options supported by `QuadStore`, `RdfStore` supports the 
-following:
+addition to all options supported by `QuadStore`, `RdfStore` requires a data factory, e.g. 
 
     opts.dataFactory = require('@rdf-data-model');  // REQUIRED: instance of RDF/JS' dataFactory 
 
@@ -416,6 +415,21 @@ The `dataFactory` option *must* be an implementation of the
 
 - [@rdfjs/data-model](https://www.npmjs.com/package/@rdfjs/data-model)
 - [N3.js' N3.DataFactory](https://www.npmjs.com/package/n3)
+
+Also, `RdfStore` can be configured with a `prefixes` object that defines a
+reversible mapping of IRIs to abbreviated forms, with the intention of reducing
+the storage cost where common HTTP prefixes are known in advance.
+
+The `prefixes` object defines a bijection using two functions `expandTerm` and
+`compactIri`, both of which take a string parameter and return a string, as in
+the following example:
+
+    opts.prefixes = {
+      expandTerm: term => term.replace(/^ex:/, 'http://example.com/'),
+      compactIri: iri => iri.replace(/^http:\/\/example\.com\//, 'ex:')
+    }
+
+This will replace the IRI `http://example.com/a` with `ex:a` in storage.
 
 #### Graph API, Quad and Term instances
 

--- a/lib/quadstore.ts
+++ b/lib/quadstore.ts
@@ -24,7 +24,7 @@ import {
   TSVoidResult,
 } from './types/index.js';
 import assert from 'assert';
-import events from 'events';
+import {EventEmitter} from 'events';
 import levelup from 'levelup';
 import {AbstractLevelDOWN} from 'abstract-leveldown';
 
@@ -46,7 +46,7 @@ import {
 import {getApproximateSize, getStream, getInit} from './get/index.js';
 import {searchStream} from './search/index.js';
 
-export class QuadStore extends events.EventEmitter implements TSStore {
+export class QuadStore extends EventEmitter implements TSStore {
 
   readonly db: AbstractLevelDOWN;
   readonly abstractLevelDOWN: AbstractLevelDOWN;

--- a/lib/rdf/serialization.ts
+++ b/lib/rdf/serialization.ts
@@ -295,16 +295,16 @@ export class RdfSerialization {
   importSimplePattern = (terms: TSRdfSimplePattern, defaultGraph: string): TSSimplePattern => {
     const importedPattern: TSSimplePattern = {};
     if (terms.subject) {
-      importedPattern.subject = this.importSimpleTerm(terms.subject, false, defaultGraph, false);
+      importedPattern.subject = this.importSimpleTerm(terms.subject, false, defaultGraph);
     }
     if (terms.predicate) {
-      importedPattern.predicate = this.importSimpleTerm(terms.predicate, false, defaultGraph, true);
+      importedPattern.predicate = this.importSimpleTerm(terms.predicate, false, defaultGraph);
     }
     if (terms.object) {
-      importedPattern.object = this.importSimpleTerm(terms.object, false, defaultGraph, false);
+      importedPattern.object = this.importSimpleTerm(terms.object, false, defaultGraph);
     }
     if (terms.graph) {
-      importedPattern.graph = this.importSimpleTerm(terms.graph, true, defaultGraph, false);
+      importedPattern.graph = this.importSimpleTerm(terms.graph, true, defaultGraph);
     }
     return importedPattern;
   };

--- a/lib/rdf/serialization.ts
+++ b/lib/rdf/serialization.ts
@@ -6,6 +6,7 @@ import {
   TSRange,
   TSRdfBinding,
   TSRdfPattern,
+  TSRdfPrefixes,
   TSRdfQuad,
   TSRdfRange,
   TSRdfSearchStage,
@@ -40,298 +41,313 @@ const xsdUnsignedShort = xsd + 'unsignedShort';
 const xsdUnsignedByte = xsd + 'unsignedByte';
 const xsdPositiveInteger = xsd + 'positiveInteger';
 
-export const exportLiteralTerm = (term: string, dataFactory: DataFactory): Literal => {
-  const [, encoding, datatype, language, value] = term.split('\u0001');
-  switch (datatype) {
-    case rdfLangString:
-      if (language !== '') {
-        return dataFactory.literal(value, language);
-      }
-      return dataFactory.literal(value);
-    default:
-      return dataFactory.literal(value, dataFactory.namedNode(datatype));
+export class RdfSerialization {
+  constructor(readonly prefixes: TSRdfPrefixes) {
   }
-}
 
-export const importLiteralTerm = (term: Literal, rangeBoundary = false): string => {
-  const { language, datatype, value } = term;
-  if (language !== '') {
-    return `\u0001\u0001${rdfLangString}\u0001${language}\u0001${value}`;
-  }
-  if (!datatype || datatype.value === xsdString) {
-    return `\u0001\u0001${xsdString}\u0001\u0001${value}`;
-  }
-  switch (datatype.value) {
-    case xsdInteger:
-    case xsdDouble:
-    case xsdDecimal:
-    case xsdNonPositiveInteger:
-    case xsdNegativeInteger:
-    case xsdLong:
-    case xsdInt:
-    case xsdShort:
-    case xsdByte:
-    case xsdNonNegativeInteger:
-    case xsdUnsignedLong:
-    case xsdUnsignedInt:
-    case xsdUnsignedShort:
-    case xsdUnsignedByte:
-    case xsdPositiveInteger:
-      if (rangeBoundary) {
-        return `\u0001number:${fpstringEncode(value)}\u0001`;
-      }
-      return `\u0001number:${fpstringEncode(value)}\u0001${datatype.value}\u0001\u0001${value}\u0001`;
-    case xsdDateTime:
-      const timestamp = new Date(value).valueOf();
-      if (rangeBoundary) {
-        return `\u0001datetime:${fpstringEncode(timestamp)}`;
-      }
-      return `\u0001datetime:${fpstringEncode(timestamp)}\u0001${datatype.value}\u0001\u0001${value}\u0001`;
-    default:
-      return `\u0001\u0001${datatype.value}\u0001\u0001${value}\u0001`;
-  }
-}
-
-export const exportTerm = (term: string, isGraph: boolean, defaultGraphValue: string, dataFactory: DataFactory): Term => {
-  if (!term) {
-    throw new Error(`Nil term "${term}". Cannot export.`);
-  }
-  if (term === defaultGraphValue) {
-    return dataFactory.defaultGraph();
-  }
-  switch (term[0]) {
-    case '_':
-      return dataFactory.blankNode(term.substr(2));
-    case '?':
-      if (dataFactory.variable) {
-        return dataFactory.variable(term.substr(1));
-      }
-      throw new Error('DataFactory does not support variables');
-    case '\u0001':
-      if (isGraph) {
-        throw new Error(`Invalid graph term "${term}" (graph cannot be a literal).`);
-      }
-      return exportLiteralTerm(term, dataFactory);
-    default:
-      return dataFactory.namedNode(term);
-  }
-}
-
-export const importSimpleTerm = (term: Term, isGraph: boolean, defaultGraphValue: string, rangeBoundary: boolean = false): string => {
-  if (!term) {
-    if (isGraph) {
-      return defaultGraphValue;
+  exportLiteralTerm = (term: string, dataFactory: DataFactory): Literal => {
+    const [, , datatype, language, value] = term.split('\u0001');
+    const datatypeIri = this.expandRequiredTerm(datatype);
+    switch (datatypeIri) {
+      case rdfLangString:
+        if (language !== '') {
+          return dataFactory.literal(value, language);
+        }
+        return dataFactory.literal(value);
+      default:
+        return dataFactory.literal(value, dataFactory.namedNode(datatypeIri));
     }
-    throw new Error(`Nil non-graph term, cannot import.`);
   }
-  switch (term.termType) {
-    case 'NamedNode':
-      return term.value;
-    case 'BlankNode':
-      return `_:${term.value}`;
-    case 'Variable':
-      return `?${term.value}`;
-    case 'DefaultGraph':
-      return defaultGraphValue;
-    case 'Literal':
-      return importLiteralTerm(term, rangeBoundary);
-    default:
-      // @ts-ignore
-      throw new Error(`Unexpected termType: "${term.termType}".`);
+
+  importLiteralTerm = (term: Literal, rangeBoundary = false): string => {
+    const { language, datatype, value } = term;
+    if (language !== '') {
+      return `\u0001\u0001${rdfLangString}\u0001${language}\u0001${value}`;
+    }
+    if (!datatype || datatype.value === xsdString) {
+      return `\u0001\u0001${xsdString}\u0001\u0001${value}`;
+    }
+    const datatypeTerm = this.prefixes.compactIri(datatype.value);
+    switch (datatype.value) {
+      case xsdInteger:
+      case xsdDouble:
+      case xsdDecimal:
+      case xsdNonPositiveInteger:
+      case xsdNegativeInteger:
+      case xsdLong:
+      case xsdInt:
+      case xsdShort:
+      case xsdByte:
+      case xsdNonNegativeInteger:
+      case xsdUnsignedLong:
+      case xsdUnsignedInt:
+      case xsdUnsignedShort:
+      case xsdUnsignedByte:
+      case xsdPositiveInteger:
+        if (rangeBoundary) {
+          return `\u0001number:${fpstringEncode(value)}\u0001`;
+        }
+        return `\u0001number:${fpstringEncode(value)}\u0001${datatypeTerm}\u0001\u0001${value}\u0001`;
+      case xsdDateTime:
+        const timestamp = new Date(value).valueOf();
+        if (rangeBoundary) {
+          return `\u0001datetime:${fpstringEncode(timestamp)}`;
+        }
+        return `\u0001datetime:${fpstringEncode(timestamp)}\u0001${datatypeTerm}\u0001\u0001${value}\u0001`;
+      default:
+        return `\u0001\u0001${datatypeTerm}\u0001\u0001${value}\u0001`;
+    }
   }
-}
 
-export const importRange = (range: TSRdfRange, rangeBoundary: boolean = false): TSRange => {
-  const importedRange: TSRange = {};
-  if (range.lt) importedRange.lt = importLiteralTerm(range.lt, rangeBoundary);
-  if (range.lte) importedRange.lte = importLiteralTerm(range.lte, rangeBoundary);
-  if (range.gt) importedRange.gt = importLiteralTerm(range.gt, rangeBoundary);
-  if (range.gte) importedRange.gte = importLiteralTerm(range.gte, rangeBoundary);
-  return importedRange;
-}
+  exportTerm = (term: string, isGraph: boolean, defaultGraphValue: string, dataFactory: DataFactory): Term => {
+    if (!term) {
+      throw new Error(`Nil term "${term}". Cannot export.`);
+    }
+    if (term === defaultGraphValue) {
+      return dataFactory.defaultGraph();
+    }
+    switch (term[0]) {
+      case '_':
+        return dataFactory.blankNode(term.substr(2));
+      case '?':
+        if (dataFactory.variable) {
+          return dataFactory.variable(term.substr(1));
+        }
+        throw new Error('DataFactory does not support variables');
+      case '\u0001':
+        if (isGraph) {
+          throw new Error(`Invalid graph term "${term}" (graph cannot be a literal).`);
+        }
+        return this.exportLiteralTerm(term, dataFactory);
+      default:
+        return dataFactory.namedNode(this.expandRequiredTerm(term));
+    }
+  }
 
-export const importTerm = (term: Term|TSRdfRange, isGraph: boolean, defaultGraphValue: string, rangeBoundary: boolean = false): string|TSRange => {
-  if ('termType' in term) {
+  importSimpleTerm = (term: Term, isGraph: boolean, defaultGraphValue: string, rangeBoundary: boolean = false): string => {
+    if (!term) {
+      if (isGraph) {
+        return defaultGraphValue;
+      }
+      throw new Error(`Nil non-graph term, cannot import.`);
+    }
     switch (term.termType) {
       case 'NamedNode':
-        return term.value;
+        return this.prefixes.compactIri(term.value);
       case 'BlankNode':
-        return '_:' + term.value;
+        return `_:${term.value}`;
       case 'Variable':
-        return '?' + term.value;
+        return `?${term.value}`;
       case 'DefaultGraph':
         return defaultGraphValue;
       case 'Literal':
-        return importLiteralTerm(term, rangeBoundary);
+        return this.importLiteralTerm(term, rangeBoundary);
       default:
         // @ts-ignore
         throw new Error(`Unexpected termType: "${term.termType}".`);
     }
-  } else if ('gt' in term  || 'gte' in term || 'lt' in term || 'lte' in term) {
-    return importRange(term, rangeBoundary);
-  } else {
-    throw new Error(`Unexpected type of "term" argument.`);
   }
-}
 
-export const importQuad = (quad: TSRdfQuad, defaultGraphValue: string): TSQuad => {
-  return {
-    subject: importSimpleTerm(quad.subject, false, defaultGraphValue),
-    predicate: importSimpleTerm(quad.predicate, false, defaultGraphValue),
-    object: importSimpleTerm(quad.object, false, defaultGraphValue),
-    graph: importSimpleTerm(quad.graph, true, defaultGraphValue),
+  importRange = (range: TSRdfRange, rangeBoundary: boolean = false): TSRange => {
+    const importedRange: TSRange = {};
+    if (range.lt) importedRange.lt = this.importLiteralTerm(range.lt, rangeBoundary);
+    if (range.lte) importedRange.lte = this.importLiteralTerm(range.lte, rangeBoundary);
+    if (range.gt) importedRange.gt = this.importLiteralTerm(range.gt, rangeBoundary);
+    if (range.gte) importedRange.gte = this.importLiteralTerm(range.gte, rangeBoundary);
+    return importedRange;
+  }
+
+  importTerm = (term: Term | TSRdfRange, isGraph: boolean, defaultGraphValue: string, rangeBoundary: boolean = false): string | TSRange => {
+    if ('termType' in term) {
+      switch (term.termType) {
+        case 'NamedNode':
+          return this.prefixes.compactIri(term.value);
+        case 'BlankNode':
+          return '_:' + term.value;
+        case 'Variable':
+          return '?' + term.value;
+        case 'DefaultGraph':
+          return defaultGraphValue;
+        case 'Literal':
+          return this.importLiteralTerm(term, rangeBoundary);
+        default:
+          // @ts-ignore
+          throw new Error(`Unexpected termType: "${term.termType}".`);
+      }
+    } else if ('gt' in term || 'gte' in term || 'lt' in term || 'lte' in term) {
+      return this.importRange(term, rangeBoundary);
+    } else {
+      throw new Error(`Unexpected type of "term" argument.`);
+    }
+  }
+
+  importQuad = (quad: TSRdfQuad, defaultGraphValue: string): TSQuad => {
+    return {
+      subject: this.importSimpleTerm(quad.subject, false, defaultGraphValue),
+      predicate: this.importSimpleTerm(quad.predicate, false, defaultGraphValue),
+      object: this.importSimpleTerm(quad.object, false, defaultGraphValue),
+      graph: this.importSimpleTerm(quad.graph, true, defaultGraphValue),
+    };
+  }
+
+  private exportQuadSubject = (term: string, dataFactory: DataFactory): Quad_Subject => {
+    switch (term[0]) {
+      case '_':
+        return dataFactory.blankNode(term.substr(2));
+      case '?':
+        if (dataFactory.variable) {
+          return dataFactory.variable(term.substr(1));
+        }
+        throw new Error('DataFactory does not support variables');
+      case '\u0001':
+        throw new Error('No literals as subject');
+      default:
+        return dataFactory.namedNode(this.expandRequiredTerm(term));
+    }
+  }
+
+  private exportQuadPredicate = (term: string, dataFactory: DataFactory): Quad_Predicate => {
+    switch (term[0]) {
+      case '_':
+        throw new Error('No blank nodes as predicates');
+      case '?':
+        if (dataFactory.variable) {
+          return dataFactory.variable(term.substr(1));
+        }
+        throw new Error('DataFactory does not support variables');
+      case '\u0001':
+        throw new Error('No literals as predicates');
+      default:
+        return dataFactory.namedNode(this.expandRequiredTerm(term));
+    }
+  }
+
+  private exportQuadObject = (term: string, dataFactory: DataFactory): Quad_Object => {
+    switch (term[0]) {
+      case '_':
+        return dataFactory.blankNode(term.substr(2));
+      case '?':
+        if (dataFactory.variable) {
+          return dataFactory.variable(term.substr(1));
+        }
+        throw new Error('DataFactory does not support variables');
+      case '\u0001':
+        return this.exportLiteralTerm(term, dataFactory);
+      default:
+        return dataFactory.namedNode(this.expandRequiredTerm(term));
+    }
+  }
+
+  private exportQuadGraph = (term: string, defaultGraphValue: string, dataFactory: DataFactory): Quad_Graph => {
+    if (term === defaultGraphValue) {
+      return dataFactory.defaultGraph();
+    }
+    switch (term[0]) {
+      case '_':
+        return dataFactory.blankNode(term.substr(2));
+      case '?':
+        if (dataFactory.variable) {
+          return dataFactory.variable(term.substr(1));
+        }
+        throw new Error('DataFactory does not support variables');
+      case '\u0001':
+        throw new Error('No literals as graphs');
+      default:
+        return dataFactory.namedNode(this.expandRequiredTerm(term));
+    }
+  }
+
+  exportQuad = (quad: TSQuad, defaultGraphValue: string, dataFactory: DataFactory): TSRdfQuad => {
+    return dataFactory.quad(
+      this.exportQuadSubject(quad.subject, dataFactory),
+      this.exportQuadPredicate(quad.predicate, dataFactory),
+      this.exportQuadObject(quad.object, dataFactory),
+      this.exportQuadGraph(quad.graph, defaultGraphValue, dataFactory)
+    );
   };
-}
 
-const exportQuadSubject = (term: string, dataFactory: DataFactory): Quad_Subject => {
-  switch (term[0]) {
-    case '_':
-      return dataFactory.blankNode(term.substr(2));
-    case '?':
-      if (dataFactory.variable) {
-        return dataFactory.variable(term.substr(1));
-      }
-      throw new Error('DataFactory does not support variables');
-    case '\u0001':
-      throw new Error('No literals as subject');
-    default:
-      return dataFactory.namedNode(term);
-  }
-}
+  exportBinding = (binding: TSBinding, defaultGraphValue: string, dataFactory: DataFactory): TSRdfBinding => {
+    const exportedBinding: TSRdfBinding = Object.create(null);
+    for (let k = 0, keys = Object.keys(binding), key; k < keys.length; k += 1) {
+      key = keys[k];
+      exportedBinding[key] = this.exportTerm(binding[key], false, defaultGraphValue, dataFactory);
+    }
+    return exportedBinding;
+  };
 
-const exportQuadPredicate = (term: string, dataFactory: DataFactory): Quad_Predicate => {
-  switch (term[0]) {
-    case '_':
-      throw new Error('No blank nodes as predicates');
-    case '?':
-      if (dataFactory.variable) {
-        return dataFactory.variable(term.substr(1));
-      }
-      throw new Error('DataFactory does not support variables');
-    case '\u0001':
-      throw new Error('No literals as predicates');
-    default:
-      return dataFactory.namedNode(term);
-  }
-}
+  importPattern = (terms: TSRdfPattern, defaultGraph: string): TSPattern => {
+    const importedTerms: TSPattern = {};
+    if (terms.subject) {
+      importedTerms.subject = this.importTerm(terms.subject, false, defaultGraph, true);
+    }
+    if (terms.predicate) {
+      importedTerms.predicate = this.importTerm(terms.predicate, false, defaultGraph, true);
+    }
+    if (terms.object) {
+      importedTerms.object = this.importTerm(terms.object, false, defaultGraph, true);
+    }
+    if (terms.graph) {
+      importedTerms.graph = this.importTerm(terms.graph, true, defaultGraph, true);
+    }
+    return importedTerms;
+  };
 
-const exportQuadObject = (term: string, dataFactory: DataFactory): Quad_Object => {
-  switch (term[0]) {
-    case '_':
-      return dataFactory.blankNode(term.substr(2));
-    case '?':
-      if (dataFactory.variable) {
-        return dataFactory.variable(term.substr(1));
-      }
-      throw new Error('DataFactory does not support variables');
-    case '\u0001':
-      return exportLiteralTerm(term, dataFactory);
-    default:
-      return dataFactory.namedNode(term);
-  }
-}
+  importSimplePattern = (terms: TSRdfSimplePattern, defaultGraph: string): TSSimplePattern => {
+    const importedPattern: TSSimplePattern = {};
+    if (terms.subject) {
+      importedPattern.subject = this.importSimpleTerm(terms.subject, false, defaultGraph, false);
+    }
+    if (terms.predicate) {
+      importedPattern.predicate = this.importSimpleTerm(terms.predicate, false, defaultGraph, true);
+    }
+    if (terms.object) {
+      importedPattern.object = this.importSimpleTerm(terms.object, false, defaultGraph, false);
+    }
+    if (terms.graph) {
+      importedPattern.graph = this.importSimpleTerm(terms.graph, true, defaultGraph, false);
+    }
+    return importedPattern;
+  };
 
-const exportQuadGraph = (term: string, defaultGraphValue: string, dataFactory: DataFactory): Quad_Graph => {
-  if (term === defaultGraphValue) {
-    return dataFactory.defaultGraph();
+  importSearchStage = (stage: TSRdfSearchStage, defaultGraph: string): TSSearchStage => {
+    switch (stage.type) {
+      case TSSearchStageType.BGP:
+        return { ...stage, pattern: this.importSimplePattern(stage.pattern, defaultGraph) };
+      case TSSearchStageType.LT:
+      case TSSearchStageType.LTE:
+      case TSSearchStageType.GT:
+      case TSSearchStageType.GTE:
+      case TSSearchStageType.STARTS_WITH:
+      case TSSearchStageType.STARTS_WITHOUT:
+        return {
+          type: stage.type,
+          args: stage.args.map(arg => this.importSimpleTerm(arg, false, defaultGraph, true)),
+        };
+      case TSSearchStageType.EQ:
+        return {
+          type: TSSearchStageType.STARTS_WITH,
+          args: stage.args.map(arg => this.importSimpleTerm(arg, false, defaultGraph, true)),
+        };
+      case TSSearchStageType.NEQ:
+        return {
+          type: TSSearchStageType.STARTS_WITHOUT,
+          args: stage.args.map(arg => this.importSimpleTerm(arg, false, defaultGraph, true)),
+        };
+      case TSSearchStageType.CONSTRUCT:
+        return {
+          type: stage.type,
+          patterns: stage.patterns.map(pattern => this.importSimplePattern(pattern, defaultGraph)),
+        };
+      case TSSearchStageType.PROJECT:
+        return <TSProjectSearchStage>stage;
+    }
   }
-  switch (term[0]) {
-    case '_':
-      return dataFactory.blankNode(term.substr(2));
-    case '?':
-      if (dataFactory.variable) {
-        return dataFactory.variable(term.substr(1));
-      }
-      throw new Error('DataFactory does not support variables');
-    case '\u0001':
-      throw new Error('No literals as graphs');
-    default:
-      return dataFactory.namedNode(term);
-  }
-}
 
-export const exportQuad = (quad: TSQuad, defaultGraphValue: string, dataFactory: DataFactory): TSRdfQuad => {
-  return dataFactory.quad(
-    exportQuadSubject(quad.subject, dataFactory),
-    exportQuadPredicate(quad.predicate, dataFactory),
-    exportQuadObject(quad.object, dataFactory),
-    exportQuadGraph(quad.graph, defaultGraphValue, dataFactory)
-  );
-};
-
-export const exportBinding = (binding: TSBinding, defaultGraphValue: string, dataFactory: DataFactory): TSRdfBinding => {
-  const exportedBinding: TSRdfBinding = Object.create(null);
-  for (let k = 0, keys = Object.keys(binding), key; k < keys.length; k += 1) {
-    key = keys[k];
-    exportedBinding[key] = exportTerm(binding[key], false, defaultGraphValue, dataFactory);
-  }
-  return exportedBinding;
-};
-
-export const importPattern = (terms: TSRdfPattern, defaultGraph: string): TSPattern => {
-  const importedTerms: TSPattern = {};
-  if (terms.subject) {
-    importedTerms.subject = importTerm(terms.subject, false, defaultGraph, true);
-  }
-  if (terms.predicate) {
-    importedTerms.predicate = importTerm(terms.predicate, false, defaultGraph, true);
-  }
-  if (terms.object) {
-    importedTerms.object = importTerm(terms.object, false, defaultGraph, true);
-  }
-  if (terms.graph) {
-    importedTerms.graph = importTerm(terms.graph, true, defaultGraph, true);
-  }
-  return importedTerms;
-};
-
-export const importSimplePattern = (terms: TSRdfSimplePattern, defaultGraph: string): TSSimplePattern => {
-  const importedPattern: TSSimplePattern = {};
-  if (terms.subject) {
-    importedPattern.subject = importSimpleTerm(terms.subject, false, defaultGraph);
-  }
-  if (terms.predicate) {
-    importedPattern.predicate = importSimpleTerm(terms.predicate, false, defaultGraph);
-  }
-  if (terms.object) {
-    importedPattern.object = importSimpleTerm(terms.object, false, defaultGraph);
-  }
-  if (terms.graph) {
-    importedPattern.graph = importSimpleTerm(terms.graph, true, defaultGraph);
-  }
-  return importedPattern;
-};
-
-export const importSearchStage = (stage: TSRdfSearchStage, defaultGraph: string): TSSearchStage => {
-  switch (stage.type) {
-    case TSSearchStageType.BGP:
-      return { ...stage, pattern: importSimplePattern(stage.pattern, defaultGraph) };
-    case TSSearchStageType.LT:
-    case TSSearchStageType.LTE:
-    case TSSearchStageType.GT:
-    case TSSearchStageType.GTE:
-    case TSSearchStageType.STARTS_WITH:
-    case TSSearchStageType.STARTS_WITHOUT:
-      return {
-        type: stage.type,
-        args: stage.args.map(arg => importSimpleTerm(arg, false, defaultGraph, true)),
-      };
-    case TSSearchStageType.EQ:
-      return {
-        type: TSSearchStageType.STARTS_WITH,
-        args: stage.args.map(arg => importSimpleTerm(arg, false, defaultGraph, true)),
-      };
-    case TSSearchStageType.NEQ:
-      return {
-        type: TSSearchStageType.STARTS_WITHOUT,
-        args: stage.args.map(arg => importSimpleTerm(arg, false, defaultGraph, true)),
-      };
-    case TSSearchStageType.CONSTRUCT:
-      return {
-        type: stage.type,
-        patterns: stage.patterns.map(pattern => importSimplePattern(pattern, defaultGraph)),
-      };
-    case TSSearchStageType.PROJECT:
-      return <TSProjectSearchStage>stage;
+  private expandRequiredTerm(term: string): string {
+    const requiredTerm = this.prefixes.expandTerm(term);
+    if (!requiredTerm) {
+      throw new Error(`Term "${term}" is disabled. Cannot export.`);
+    }
+    return requiredTerm;
   }
 }

--- a/lib/rdf/serialization.ts
+++ b/lib/rdf/serialization.ts
@@ -47,7 +47,7 @@ export class RdfSerialization {
 
   exportLiteralTerm = (term: string, dataFactory: DataFactory): Literal => {
     const [, , datatype, language, value] = term.split('\u0001');
-    const datatypeIri = this.expandRequiredTerm(datatype);
+    const datatypeIri = this.prefixes.expandTerm(datatype);
     switch (datatypeIri) {
       case rdfLangString:
         if (language !== '') {
@@ -120,7 +120,7 @@ export class RdfSerialization {
         }
         return this.exportLiteralTerm(term, dataFactory);
       default:
-        return dataFactory.namedNode(this.expandRequiredTerm(term));
+        return dataFactory.namedNode(this.prefixes.expandTerm(term));
     }
   }
 
@@ -202,7 +202,7 @@ export class RdfSerialization {
       case '\u0001':
         throw new Error('No literals as subject');
       default:
-        return dataFactory.namedNode(this.expandRequiredTerm(term));
+        return dataFactory.namedNode(this.prefixes.expandTerm(term));
     }
   }
 
@@ -218,7 +218,7 @@ export class RdfSerialization {
       case '\u0001':
         throw new Error('No literals as predicates');
       default:
-        return dataFactory.namedNode(this.expandRequiredTerm(term));
+        return dataFactory.namedNode(this.prefixes.expandTerm(term));
     }
   }
 
@@ -234,7 +234,7 @@ export class RdfSerialization {
       case '\u0001':
         return this.exportLiteralTerm(term, dataFactory);
       default:
-        return dataFactory.namedNode(this.expandRequiredTerm(term));
+        return dataFactory.namedNode(this.prefixes.expandTerm(term));
     }
   }
 
@@ -253,7 +253,7 @@ export class RdfSerialization {
       case '\u0001':
         throw new Error('No literals as graphs');
       default:
-        return dataFactory.namedNode(this.expandRequiredTerm(term));
+        return dataFactory.namedNode(this.prefixes.expandTerm(term));
     }
   }
 
@@ -341,13 +341,5 @@ export class RdfSerialization {
       case TSSearchStageType.PROJECT:
         return <TSProjectSearchStage>stage;
     }
-  }
-
-  private expandRequiredTerm(term: string): string {
-    const requiredTerm = this.prefixes.expandTerm(term);
-    if (!requiredTerm) {
-      throw new Error(`Term "${term}" is disabled. Cannot export.`);
-    }
-    return requiredTerm;
   }
 }

--- a/lib/rdf/serialization.ts
+++ b/lib/rdf/serialization.ts
@@ -42,10 +42,13 @@ const xsdUnsignedByte = xsd + 'unsignedByte';
 const xsdPositiveInteger = xsd + 'positiveInteger';
 
 export class RdfSerialization {
-  constructor(readonly prefixes: TSRdfPrefixes) {
+  readonly prefixes: TSRdfPrefixes
+
+  constructor(prefixes: TSRdfPrefixes) {
+    this.prefixes = prefixes;
   }
 
-  exportLiteralTerm = (term: string, dataFactory: DataFactory): Literal => {
+  exportLiteralTerm(term: string, dataFactory: DataFactory): Literal {
     const [, , datatype, language, value] = term.split('\u0001');
     const datatypeIri = this.prefixes.expandTerm(datatype);
     switch (datatypeIri) {
@@ -59,7 +62,7 @@ export class RdfSerialization {
     }
   }
 
-  importLiteralTerm = (term: Literal, rangeBoundary = false): string => {
+  importLiteralTerm(term: Literal, rangeBoundary = false): string {
     const { language, datatype, value } = term;
     if (language !== '') {
       return `\u0001\u0001${rdfLangString}\u0001${language}\u0001${value}`;
@@ -99,7 +102,7 @@ export class RdfSerialization {
     }
   }
 
-  exportTerm = (term: string, isGraph: boolean, defaultGraphValue: string, dataFactory: DataFactory): Term => {
+  exportTerm(term: string, isGraph: boolean, defaultGraphValue: string, dataFactory: DataFactory): Term {
     if (!term) {
       throw new Error(`Nil term "${term}". Cannot export.`);
     }
@@ -124,7 +127,7 @@ export class RdfSerialization {
     }
   }
 
-  importSimpleTerm = (term: Term, isGraph: boolean, defaultGraphValue: string, rangeBoundary: boolean = false): string => {
+  importSimpleTerm(term: Term, isGraph: boolean, defaultGraphValue: string, rangeBoundary: boolean = false): string {
     if (!term) {
       if (isGraph) {
         return defaultGraphValue;
@@ -148,7 +151,7 @@ export class RdfSerialization {
     }
   }
 
-  importRange = (range: TSRdfRange, rangeBoundary: boolean = false): TSRange => {
+  importRange(range: TSRdfRange, rangeBoundary: boolean = false): TSRange {
     const importedRange: TSRange = {};
     if (range.lt) importedRange.lt = this.importLiteralTerm(range.lt, rangeBoundary);
     if (range.lte) importedRange.lte = this.importLiteralTerm(range.lte, rangeBoundary);
@@ -157,7 +160,7 @@ export class RdfSerialization {
     return importedRange;
   }
 
-  importTerm = (term: Term | TSRdfRange, isGraph: boolean, defaultGraphValue: string, rangeBoundary: boolean = false): string | TSRange => {
+  importTerm(term: Term | TSRdfRange, isGraph: boolean, defaultGraphValue: string, rangeBoundary: boolean = false): string | TSRange {
     if ('termType' in term) {
       switch (term.termType) {
         case 'NamedNode':
@@ -181,7 +184,7 @@ export class RdfSerialization {
     }
   }
 
-  importQuad = (quad: TSRdfQuad, defaultGraphValue: string): TSQuad => {
+  importQuad(quad: TSRdfQuad, defaultGraphValue: string): TSQuad {
     return {
       subject: this.importSimpleTerm(quad.subject, false, defaultGraphValue),
       predicate: this.importSimpleTerm(quad.predicate, false, defaultGraphValue),
@@ -190,7 +193,7 @@ export class RdfSerialization {
     };
   }
 
-  private exportQuadSubject = (term: string, dataFactory: DataFactory): Quad_Subject => {
+  private exportQuadSubject(term: string, dataFactory: DataFactory): Quad_Subject {
     switch (term[0]) {
       case '_':
         return dataFactory.blankNode(term.substr(2));
@@ -206,7 +209,7 @@ export class RdfSerialization {
     }
   }
 
-  private exportQuadPredicate = (term: string, dataFactory: DataFactory): Quad_Predicate => {
+  private exportQuadPredicate(term: string, dataFactory: DataFactory): Quad_Predicate {
     switch (term[0]) {
       case '_':
         throw new Error('No blank nodes as predicates');
@@ -222,7 +225,7 @@ export class RdfSerialization {
     }
   }
 
-  private exportQuadObject = (term: string, dataFactory: DataFactory): Quad_Object => {
+  private exportQuadObject(term: string, dataFactory: DataFactory): Quad_Object {
     switch (term[0]) {
       case '_':
         return dataFactory.blankNode(term.substr(2));
@@ -238,7 +241,7 @@ export class RdfSerialization {
     }
   }
 
-  private exportQuadGraph = (term: string, defaultGraphValue: string, dataFactory: DataFactory): Quad_Graph => {
+  private exportQuadGraph(term: string, defaultGraphValue: string, dataFactory: DataFactory): Quad_Graph {
     if (term === defaultGraphValue) {
       return dataFactory.defaultGraph();
     }
@@ -257,7 +260,7 @@ export class RdfSerialization {
     }
   }
 
-  exportQuad = (quad: TSQuad, defaultGraphValue: string, dataFactory: DataFactory): TSRdfQuad => {
+  exportQuad(quad: TSQuad, defaultGraphValue: string, dataFactory: DataFactory): TSRdfQuad {
     return dataFactory.quad(
       this.exportQuadSubject(quad.subject, dataFactory),
       this.exportQuadPredicate(quad.predicate, dataFactory),
@@ -266,7 +269,7 @@ export class RdfSerialization {
     );
   };
 
-  exportBinding = (binding: TSBinding, defaultGraphValue: string, dataFactory: DataFactory): TSRdfBinding => {
+  exportBinding(binding: TSBinding, defaultGraphValue: string, dataFactory: DataFactory): TSRdfBinding {
     const exportedBinding: TSRdfBinding = Object.create(null);
     for (let k = 0, keys = Object.keys(binding), key; k < keys.length; k += 1) {
       key = keys[k];
@@ -275,7 +278,7 @@ export class RdfSerialization {
     return exportedBinding;
   };
 
-  importPattern = (terms: TSRdfPattern, defaultGraph: string): TSPattern => {
+  importPattern(terms: TSRdfPattern, defaultGraph: string): TSPattern {
     const importedTerms: TSPattern = {};
     if (terms.subject) {
       importedTerms.subject = this.importTerm(terms.subject, false, defaultGraph, true);
@@ -292,7 +295,7 @@ export class RdfSerialization {
     return importedTerms;
   };
 
-  importSimplePattern = (terms: TSRdfSimplePattern, defaultGraph: string): TSSimplePattern => {
+  importSimplePattern(terms: TSRdfSimplePattern, defaultGraph: string): TSSimplePattern {
     const importedPattern: TSSimplePattern = {};
     if (terms.subject) {
       importedPattern.subject = this.importSimpleTerm(terms.subject, false, defaultGraph);
@@ -309,7 +312,7 @@ export class RdfSerialization {
     return importedPattern;
   };
 
-  importSearchStage = (stage: TSRdfSearchStage, defaultGraph: string): TSSearchStage => {
+  importSearchStage(stage: TSRdfSearchStage, defaultGraph: string): TSSearchStage {
     switch (stage.type) {
       case TSSearchStageType.BGP:
         return { ...stage, pattern: this.importSimplePattern(stage.pattern, defaultGraph) };

--- a/lib/rdfstore.ts
+++ b/lib/rdfstore.ts
@@ -63,7 +63,7 @@ export class RdfStore extends EventEmitter implements TSRdfStore, Store {
     assert(isDataFactory(opts.dataFactory), 'Invalid "opts" argument: "opts.dataFactory" is not an instance of DataFactory');
     const {dataFactory} = opts;
     this.dataFactory = dataFactory;
-    this.serialization = new RdfSerialization(opts.prefixes ?? {
+    this.serialization = new RdfSerialization(opts.prefixes || {
       expandTerm: term => term,
       compactIri: iri => iri
     });
@@ -97,7 +97,7 @@ export class RdfStore extends EventEmitter implements TSRdfStore, Store {
       .catch((err) => {
         // TODO: is the destroy() method really supported by AsyncIterator?
         // @ts-ignore
-        iterator.destroy();
+        iterator.destroy(err);
       });
     return <Stream<Quad>>iterator;
   }
@@ -180,25 +180,25 @@ export class RdfStore extends EventEmitter implements TSRdfStore, Store {
     }
   }
 
-  async put(quad: TSRdfQuad, opts: TSEmptyOpts | undefined = {}): Promise<TSRdfVoidResult> {
+  async put(quad: TSRdfQuad, opts?: TSEmptyOpts): Promise<TSRdfVoidResult> {
     return await this.quadstore.put(this.serialization.importQuad(quad, this.quadstore.defaultGraph), opts);
   }
 
-  async multiPut(quads: TSRdfQuad[], opts: TSEmptyOpts | undefined = {}): Promise<TSRdfVoidResult> {
+  async multiPut(quads: TSRdfQuad[], opts?: TSEmptyOpts): Promise<TSRdfVoidResult> {
     const importedQuads = quads.map(quad => this.serialization.importQuad(quad, this.quadstore.defaultGraph));
     return await this.quadstore.multiPut(importedQuads, opts);
   }
 
-  async del(oldQuad: TSRdfQuad, opts: TSEmptyOpts): Promise<TSRdfVoidResult> {
+  async del(oldQuad: TSRdfQuad, opts?: TSEmptyOpts): Promise<TSRdfVoidResult> {
     return await this.quadstore.del(this.serialization.importQuad(oldQuad, this.quadstore.defaultGraph), opts);
   }
 
-  async multiDel(oldQuads: TSRdfQuad[], opts: TSEmptyOpts): Promise<TSRdfVoidResult> {
+  async multiDel(oldQuads: TSRdfQuad[], opts?: TSEmptyOpts): Promise<TSRdfVoidResult> {
     let importedOldQuads = oldQuads.map(quad => this.serialization.importQuad(quad, this.quadstore.defaultGraph));
     return await this.quadstore.multiDel(importedOldQuads, opts);
   }
 
-  async patch(oldQuad: TSRdfQuad, newQuad: TSRdfQuad, opts: TSEmptyOpts): Promise<TSRdfVoidResult> {
+  async patch(oldQuad: TSRdfQuad, newQuad: TSRdfQuad, opts?: TSEmptyOpts): Promise<TSRdfVoidResult> {
     return await this.quadstore.patch(
       this.serialization.importQuad(oldQuad, this.quadstore.defaultGraph),
       this.serialization.importQuad(newQuad, this.quadstore.defaultGraph),
@@ -206,7 +206,7 @@ export class RdfStore extends EventEmitter implements TSRdfStore, Store {
     );
   }
 
-  async multiPatch(oldQuads: TSRdfQuad[], newQuads: TSRdfQuad[], opts: TSEmptyOpts): Promise<TSRdfVoidResult> {
+  async multiPatch(oldQuads: TSRdfQuad[], newQuads: TSRdfQuad[], opts?: TSEmptyOpts): Promise<TSRdfVoidResult> {
     const importedOldQuads = oldQuads.map(quad => this.serialization.importQuad(quad, this.quadstore.defaultGraph));
     const importedNewQuads = newQuads.map(quad => this.serialization.importQuad(quad, this.quadstore.defaultGraph));
     return await this.quadstore.multiPatch(importedOldQuads, importedNewQuads, opts);

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -364,12 +364,18 @@ export interface TSRdfProjectSearchStage {
 
 export type TSRdfSearchStage = TSRdfBgpSearchStage|TSRdfFilterSearchStage|TSRdfConstructSearchStage|TSRdfProjectSearchStage;
 
+export interface TSRdfPrefixes {
+  expandTerm(term: string): string | null;
+  compactIri(iri: string): string;
+}
+
 export interface TSRdfStoreOpts {
   backend: AbstractLevelDOWN,
   boundary?: string,
   separator?: string,
   indexes?: TSTermName[][],
   dataFactory: DataFactory,
+  prefixes?: TSRdfPrefixes
 }
 
 export interface TSSparqlOpts {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -365,7 +365,7 @@ export interface TSRdfProjectSearchStage {
 export type TSRdfSearchStage = TSRdfBgpSearchStage|TSRdfFilterSearchStage|TSRdfConstructSearchStage|TSRdfProjectSearchStage;
 
 export interface TSRdfPrefixes {
-  expandTerm(term: string): string | null;
+  expandTerm(term: string): string;
   compactIri(iri: string): string;
 }
 

--- a/test/main.js
+++ b/test/main.js
@@ -12,11 +12,13 @@ const rdfSuite = require('./rdf');
 const searchSuite = require('./search');
 const rdfStoreSuite = require('./rdfstore');
 const quadStoreSuite = require('./quadstore');
+const serialization = require('./serialization');
 
 const remove = util.promisify(fs.remove);
 
 rdfSuite();
 searchSuite();
+serialization();
 
 describe('MemDOWN backend, standard indexes', () => {
 
@@ -26,6 +28,21 @@ describe('MemDOWN backend, standard indexes', () => {
   });
 
   quadStoreSuite();
+  rdfStoreSuite();
+
+});
+
+describe('MemDOWN backend, standard indexes, prefixes', () => {
+
+  beforeEach(async function () {
+    this.db = memdown();
+    this.indexes = null;
+    this.prefixes = {
+      expandTerm: term => term.replace(/^ex:/, 'http://ex.com/'),
+      compactIri: iri => iri.replace(/^http:\/\/ex\.com\//, 'ex:')
+    };
+  });
+
   rdfStoreSuite();
 
 });

--- a/test/rdfstore.js
+++ b/test/rdfstore.js
@@ -15,6 +15,7 @@ module.exports = () => {
         dataFactory,
         backend: this.db,
         indexes: this.indexes,
+        prefixes: this.prefixes
       });
       await utils.waitForEvent(this.store, 'ready');
     });

--- a/test/serialization.js
+++ b/test/serialization.js
@@ -1,0 +1,34 @@
+const dataFactory = require('@rdfjs/data-model');
+const { RdfSerialization } = require('../dist/lib/rdf/serialization');
+
+module.exports = () => {
+  describe('Serialization', () => {
+    beforeEach(() => {
+      this.serialization = new RdfSerialization(dataFactory, {
+        expandTerm: term => term.replace(/^ex:/, 'http://ex.com/'),
+        compactIri: iri => iri.replace(/^http:\/\/ex\.com\//, 'ex:')
+      });
+    });
+
+    it('should apply prefixes to import named node', () => {
+      const term = this.serialization.importTerm(dataFactory.namedNode('http://ex.com/a'), false, '');
+      should(term).equal('ex:a');
+    });
+
+    it('should apply prefixes to import literal datatype', () => {
+      const literal = this.serialization.importTerm(
+        dataFactory.literal('a', dataFactory.namedNode('http://ex.com/a')), false, '');
+      should(literal).equal(`\u0001\u0001ex:a\u0001\u0001a\u0001`);
+    });
+
+    it('should un-apply prefixes to export named node', () => {
+      const iri = this.serialization.exportTerm('ex:a', false, '');
+      should(iri.equals(dataFactory.namedNode('http://ex.com/a'))).equal(true);
+    });
+
+    it('should un-apply prefixes to export literal datatype', () => {
+      const literal = this.serialization.exportTerm(`\u0001\u0001ex:a\u0001\u0001a\u0001`, false, '');
+      should(literal.equals(dataFactory.literal('a', dataFactory.namedNode('http://ex.com/a')))).equal(true);
+    });
+  })
+};


### PR DESCRIPTION
This is a *speculative* PR for the addition of a hook to allow compaction of IRIs in the storage back-end.

This originated in an attempt to improve performance when using Level.js in the browser. Actually it made no difference to transaction duration. However, it did reduce storage volume by about 40% in my use-case, and it may be useful to others.

The principle is as follows. When an `RdfStore` is created, you can optionally include a `prefixes` object, which is required to have two methods:
1. `expandTerm(term: string, expandVocab?: boolean): string`, which is used to expand an IRI from what is stored.
1. `compactIri(iri: string, vocab?: boolean): string`, which is used to compact an IRI ready for storage.

These methods intentionally follow the contract of the same methods in the `Parser` object from https://github.com/rubensworks/jsonld-context-parser.js (also convenient for me as I'm using JSON-LD extensively).

Note that I also removed some *unused* Term import/export methods, which were anyway generally incompatible with my approach since they did not specify the term position (S, P, or O).

If this is of interest, I'd be happy to add tests and documentation. However I'm aware that a big refactor is in the works, so I didn't want to go too far.