### PR TITLE
Fixed exact-match to numeric literal

### DIFF
--- a/lib/rdf/serialization.ts
+++ b/lib/rdf/serialization.ts
@@ -162,7 +162,7 @@ export const importTerm = (term: Term|TSRdfRange, isGraph: boolean, defaultGraph
       case 'DefaultGraph':
         return defaultGraphValue;
       case 'Literal':
-        return importLiteralTerm(term, rangeBoundary);
+        return importLiteralTerm(term);
       default:
         // @ts-ignore
         throw new Error(`Unexpected termType: "${term.termType}".`);


### PR DESCRIPTION
I came across this problem in testing #91. Without the fix in serialization.ts, the new test fails.

SPARQL test results are:

test-rdf:sparql10: 219 / 438 tests succeeded

test-rdf:sparql11: 97 / 271 tests succeeded

I'll merge this change into #91 too if OK.