### PR TITLE
#119: Key-value interface: optional pre-write

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,22 @@ are expected to be maps of term names to instances of the
 [dm-3]: https://github.com/rdfjs-base/data-model
 [dm-4]: https://github.com/RubenVerborgh/AsyncIterator#readme
 
+### Access to the backend
+
+The backend of a `quadstore` can be accessed with the `db` property, to perform
+additional storage operations independently of quads.
+
+In order to perform write operations atomically with quad storage, the `put`,
+`multiPut`, `del`, `multiDel`, `patch` and `multiPatch` methods accept a
+`preWrite` option which defines a procedure to augment the batch, as in the
+following example:
+
+```js
+await store.put(dataFactory.quad(/* ... */), {
+  preWrite: batch => batch.put('my.key', Buffer.from('my.value'))
+});
+```
+
 ### Quadstore class
 
 ```js
@@ -346,6 +362,14 @@ await store.put(dataFactory.quad(/* ... */));
 
 Stores a new quad. Does *not* throw or return an error if the quad already exists.
 
+This method also accepts an optional `opts` parameter with the following
+properties:
+
+- `opts.preWrite`: this can be set to a function which accepts a
+  [chainedBatch](https://github.com/Level/abstract-leveldown#chainedbatch) and
+  performs additional backend operations atomically with the `put` operation.
+  See [Access to the backend](#access-to-the-backend) for more information.
+
 ### Quadstore.prototype.multiPut()
 
 ```js
@@ -357,6 +381,14 @@ await store.multiPut([
 
 Stores new quads. Does *not* throw or return an error if quads already exists.
 
+This method also accepts an optional `opts` parameter with the following
+properties:
+
+- `opts.preWrite`: this can be set to a function which accepts a
+  [chainedBatch](https://github.com/Level/abstract-leveldown#chainedbatch) and
+  performs additional backend operations atomically with the `put` operation.
+  See [Access to the backend](#access-to-the-backend) for more information.
+
 ### Quadstore.prototype.del()
 
 This method deletes a single quad. It Does *not* throw or return an error if the 
@@ -365,7 +397,15 @@ specified quad is not present in the store.
 ```js
 await store.del(dataFactory.quad(/* ... */));
 ```
-    
+
+This method also accepts an optional `opts` parameter with the following
+properties:
+
+- `opts.preWrite`: this can be set to a function which accepts a
+  [chainedBatch](https://github.com/Level/abstract-leveldown#chainedbatch) and
+  performs additional backend operations atomically with the `put` operation.
+  See [Access to the backend](#access-to-the-backend) for more information.
+
 ### Quadstore.prototype.multiDel()
 
 This method deletes multiple quads. It Does *not* throw or return an error if
@@ -377,6 +417,14 @@ await store.multiDel([
   dataFactory.quad(/* ... */),
 ]);
 ```
+
+This method also accepts an optional `opts` parameter with the following
+properties:
+
+- `opts.preWrite`: this can be set to a function which accepts a
+  [chainedBatch](https://github.com/Level/abstract-leveldown#chainedbatch) and
+  performs additional backend operations atomically with the `put` operation.
+  See [Access to the backend](#access-to-the-backend) for more information.
 
 ### Quadstore.prototype.patch()
 
@@ -390,7 +438,15 @@ await store.patch(
   dataFactory.quad(/* ... */),  // will be inserted
 );
 ```
-    
+
+This method also accepts an optional `opts` parameter with the following
+properties:
+
+- `opts.preWrite`: this can be set to a function which accepts a
+  [chainedBatch](https://github.com/Level/abstract-leveldown#chainedbatch) and
+  performs additional backend operations atomically with the `put` operation.
+  See [Access to the backend](#access-to-the-backend) for more information.
+
 ### Quadstore.prototype.multiPatch()
 
 This method deletes and inserts quads in a single operation. It Does *not* 
@@ -413,6 +469,14 @@ const newQuads = [ // will be inserted
 
 await store.multiPatch(oldQuads, newQuads);
 ```
+
+This method also accepts an optional `opts` parameter with the following
+properties:
+
+- `opts.preWrite`: this can be set to a function which accepts a
+  [chainedBatch](https://github.com/Level/abstract-leveldown#chainedbatch) and
+  performs additional backend operations atomically with the `put` operation.
+  See [Access to the backend](#access-to-the-backend) for more information.
 
 ### Quadstore.prototype.getStream()
 

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,10 @@ export {
   PutStreamOpts,
   DelStreamOpts,
 
+  DelOpts,
+  PutOpts,
+  PatchOpts,
+
   StoreOpts,
 
   Quad,

--- a/lib/quadstore.ts
+++ b/lib/quadstore.ts
@@ -21,7 +21,7 @@ import {DataFactory, Quad, Quad_Graph, Quad_Object, Quad_Predicate, Quad_Subject
 import {
   DefaultGraphMode,
   DelStreamOpts,
-  EmptyOpts,
+  BatchOpts,
   GetOpts,
   InternalIndex,
   ImportedPattern,
@@ -39,7 +39,7 @@ import {
   SparqlOpts,
   TermName, Prefixes,
 } from './types';
-import {AbstractLevelDOWN} from 'abstract-leveldown';
+import {AbstractChainedBatch, AbstractLevelDOWN} from 'abstract-leveldown';
 import {getApproximateSize, getStream, compileCanBeUsedWithPatternFn, compileGetKeyFn} from './get';
 import {Algebra} from 'sparqlalgebrajs';
 import {newEngine, ActorInitSparql} from 'quadstore-comunica';
@@ -105,7 +105,7 @@ export class Quadstore implements Store {
   }
 
   protected waitForStatus(status: string, timeout: number = 200) {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       const t = setTimeout(() => {
         clearInterval(i);
         clearTimeout(t);
@@ -229,18 +229,18 @@ export class Quadstore implements Store {
     return sparql(this, query, opts);
   }
 
-  async put(quad: Quad, opts: EmptyOpts = emptyObject): Promise<VoidResult> {
+  async put(quad: Quad, opts: BatchOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const importedQuad = importQuad(quad, this.defaultGraph, this.prefixes);
     const value = serializeImportedQuad(importedQuad);
     const batch = this.indexes.reduce((indexBatch, i) => {
       return indexBatch.put(i.getKey(importedQuad), value);
     }, this.db.batch());
-    await pFromCallback((cb) => { batch.write(cb); });
+    await this.writeBatch(batch, opts);
     return { type: ResultType.VOID };
   }
 
-  async multiPut(quads: Quad[], opts: EmptyOpts = emptyObject): Promise<VoidResult> {
+  async multiPut(quads: Quad[], opts: BatchOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const batch = quads.reduce((quadBatch, quad) => {
       const importedQuad = importQuad(quad, this.defaultGraph, this.prefixes);
@@ -249,20 +249,20 @@ export class Quadstore implements Store {
         return indexBatch.put(index.getKey(importedQuad), value);
       }, quadBatch);
     }, this.db.batch());
-    await pFromCallback((cb) => { batch.write(cb); });
+    await this.writeBatch(batch, opts);
     return { type: ResultType.VOID };
   }
 
-  async del(quad: Quad, opts: EmptyOpts = emptyObject): Promise<VoidResult> {
+  async del(quad: Quad, opts: BatchOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const batch = this.indexes.reduce((batch, i) => {
       return batch.del(i.getKey(importQuad(quad, this.defaultGraph, this.prefixes)));
     }, this.db.batch());
-    await pFromCallback((cb) => { batch.write(cb); });
+    await this.writeBatch(batch, opts);
     return { type: ResultType.VOID };
   }
 
-  async multiDel(quads: Quad[], opts: EmptyOpts = emptyObject): Promise<VoidResult> {
+  async multiDel(quads: Quad[], opts: BatchOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const batch = quads.reduce((quadBatch, quad) => {
       const importedQuad = importQuad(quad, this.defaultGraph, this.prefixes);
@@ -270,12 +270,11 @@ export class Quadstore implements Store {
         return indexBatch.del(index.getKey(importedQuad));
       }, quadBatch);
     }, this.db.batch());
-
-    await pFromCallback((cb) => { batch.write(cb); });
+    await this.writeBatch(batch, opts);
     return { type: ResultType.VOID };
   }
 
-  async patch(oldQuad: Quad, newQuad: Quad, opts: EmptyOpts = emptyObject): Promise<VoidResult> {
+  async patch(oldQuad: Quad, newQuad: Quad, opts: BatchOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const importedNewQuad = importQuad(newQuad, this.defaultGraph, this.prefixes);
     const value = serializeImportedQuad(importedNewQuad);
@@ -283,11 +282,11 @@ export class Quadstore implements Store {
       return indexBatch.del(i.getKey(importQuad(oldQuad, this.defaultGraph, this.prefixes)))
         .put(i.getKey(importedNewQuad), value);
     }, this.db.batch());
-    await pFromCallback((cb) => { batch.write(cb); });
+    await this.writeBatch(batch, opts);
     return { type: ResultType.VOID };
   }
 
-  async multiPatch(oldQuads: Quad[], newQuads: Quad[], opts: EmptyOpts = emptyObject): Promise<VoidResult> {
+  async multiPatch(oldQuads: Quad[], newQuads: Quad[], opts: BatchOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     let batch = this.db.batch();
     batch = oldQuads.reduce((quadBatch, oldQuad) => {
@@ -302,8 +301,14 @@ export class Quadstore implements Store {
         return indexBatch.put(index.getKey(importedNewQuad), value);
       }, quadBatch);
     }, batch);
-    await pFromCallback((cb) => { batch.write(cb); });
+    await this.writeBatch(batch, opts);
     return { type: ResultType.VOID };
+  }
+
+  private async writeBatch(batch: AbstractChainedBatch, opts: BatchOpts) {
+    if (opts.preWrite != null)
+      await opts.preWrite(batch);
+    await pFromCallback((cb) => { batch.write(cb); });
   }
 
   async get(pattern: Pattern, opts: GetOpts = emptyObject): Promise<QuadArrayResult> {

--- a/lib/quadstore.ts
+++ b/lib/quadstore.ts
@@ -22,6 +22,9 @@ import {
   DefaultGraphMode,
   DelStreamOpts,
   BatchOpts,
+  DelOpts,
+  PutOpts,
+  PatchOpts,
   GetOpts,
   InternalIndex,
   ImportedPattern,
@@ -229,7 +232,7 @@ export class Quadstore implements Store {
     return sparql(this, query, opts);
   }
 
-  async put(quad: Quad, opts: BatchOpts = emptyObject): Promise<VoidResult> {
+  async put(quad: Quad, opts: PutOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const importedQuad = importQuad(quad, this.defaultGraph, this.prefixes);
     const value = serializeImportedQuad(importedQuad);
@@ -240,7 +243,7 @@ export class Quadstore implements Store {
     return { type: ResultType.VOID };
   }
 
-  async multiPut(quads: Quad[], opts: BatchOpts = emptyObject): Promise<VoidResult> {
+  async multiPut(quads: Quad[], opts: PutOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const batch = quads.reduce((quadBatch, quad) => {
       const importedQuad = importQuad(quad, this.defaultGraph, this.prefixes);
@@ -253,7 +256,7 @@ export class Quadstore implements Store {
     return { type: ResultType.VOID };
   }
 
-  async del(quad: Quad, opts: BatchOpts = emptyObject): Promise<VoidResult> {
+  async del(quad: Quad, opts: DelOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const batch = this.indexes.reduce((batch, i) => {
       return batch.del(i.getKey(importQuad(quad, this.defaultGraph, this.prefixes)));
@@ -262,7 +265,7 @@ export class Quadstore implements Store {
     return { type: ResultType.VOID };
   }
 
-  async multiDel(quads: Quad[], opts: BatchOpts = emptyObject): Promise<VoidResult> {
+  async multiDel(quads: Quad[], opts: DelOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const batch = quads.reduce((quadBatch, quad) => {
       const importedQuad = importQuad(quad, this.defaultGraph, this.prefixes);
@@ -274,7 +277,7 @@ export class Quadstore implements Store {
     return { type: ResultType.VOID };
   }
 
-  async patch(oldQuad: Quad, newQuad: Quad, opts: BatchOpts = emptyObject): Promise<VoidResult> {
+  async patch(oldQuad: Quad, newQuad: Quad, opts: PatchOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     const importedNewQuad = importQuad(newQuad, this.defaultGraph, this.prefixes);
     const value = serializeImportedQuad(importedNewQuad);
@@ -286,7 +289,7 @@ export class Quadstore implements Store {
     return { type: ResultType.VOID };
   }
 
-  async multiPatch(oldQuads: Quad[], newQuads: Quad[], opts: BatchOpts = emptyObject): Promise<VoidResult> {
+  async multiPatch(oldQuads: Quad[], newQuads: Quad[], opts: PatchOpts = emptyObject): Promise<VoidResult> {
     this.ensureReady();
     let batch = this.db.batch();
     batch = oldQuads.reduce((quadBatch, oldQuad) => {
@@ -306,8 +309,9 @@ export class Quadstore implements Store {
   }
 
   private async writeBatch(batch: AbstractChainedBatch, opts: BatchOpts) {
-    if (opts.preWrite != null)
+    if (opts.preWrite) {
       await opts.preWrite(batch);
+    }
     await pFromCallback((cb) => { batch.write(cb); });
   }
 

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -5,7 +5,20 @@ import {AsyncIterator} from 'asynciterator';
 import {Literal, DataFactory, Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph, Quad, Term} from 'rdf-js';
 
 export interface BatchOpts {
-  preWrite?: (batch: AbstractChainedBatch) => Promise<unknown> | void;
+  /**
+   * Factory for additional Key-Value Pair operations to be included atomically
+   * in a batch.
+   */
+  preWrite?: (batch: AbstractChainedBatch) => Promise<any> | any;
+}
+
+export interface DelOpts extends BatchOpts {
+}
+
+export interface PutOpts extends BatchOpts {
+}
+
+export interface PatchOpts extends BatchOpts {
 }
 
 export enum TermName {

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -1,10 +1,12 @@
 
 import { Readable } from 'stream';
-import { AbstractLevelDOWN } from 'abstract-leveldown'
+import { AbstractChainedBatch, AbstractLevelDOWN } from 'abstract-leveldown'
 import {AsyncIterator} from 'asynciterator';
 import {Literal, DataFactory, Quad_Subject, Quad_Predicate, Quad_Object, Quad_Graph, Quad, Term} from 'rdf-js';
 
-export interface EmptyOpts {}
+export interface BatchOpts {
+  preWrite?: (batch: AbstractChainedBatch) => Promise<unknown> | void;
+}
 
 export enum TermName {
   SUBJECT = 'subject',

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -123,7 +123,7 @@ export const consumeInBatches = async <T>(iterator: TSReadable<T>, batchSize: nu
 };
 
 export const consumeOneByOne = async <T>(iterator: TSReadable<T>, onEachItem: (item: T) => Promise<any>) => {
-  return new Promise((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     let ended = false;
     let waiting = false;
     let working = false;

--- a/test/quadstore.js
+++ b/test/quadstore.js
@@ -33,5 +33,6 @@ module.exports = () => {
     require('./quadstore.prototype.import')();
     require('./quadstore.prototype.removematches')();
 
+    require('./quadstore.prewrite')();
   });
 };

--- a/test/quadstore.prewrite.js
+++ b/test/quadstore.prewrite.js
@@ -1,0 +1,91 @@
+
+'use strict';
+
+const _ = require('../dist/lib/utils');
+const should = require('should');
+
+module.exports = () => {
+
+  describe('QuadStore preWrite option', () => {
+
+    let quads;
+
+    beforeEach(function () {
+      const { dataFactory } = this;
+      quads = [
+        dataFactory.quad(
+          dataFactory.namedNode('ex://s'),
+          dataFactory.namedNode('ex://p'),
+          dataFactory.namedNode('ex://o'),
+          dataFactory.namedNode('ex://g'),
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('ex://s2'),
+          dataFactory.namedNode('ex://p2'),
+          dataFactory.namedNode('ex://o2'),
+          dataFactory.namedNode('ex://g2'),
+        ),
+      ];
+    });
+    
+    it('should pre-write kvps when putting a quad', async function () {
+      const { store } = this;
+      await store.put(quads[0], {
+        preWrite: batch => batch.put('key1', Buffer.from('value1'))
+      });
+      const value = await _.pFromCallback(cb => store.db.get('key1', cb));
+      should(Buffer.from('value1').equals(value)).be.true();
+    });
+
+    it('should pre-write kvps when putting quads', async function () {
+      const { store } = this;
+      await store.multiPut(quads, {
+        preWrite: batch => batch.put('key1', Buffer.from('value1'))
+      });
+      const value = await _.pFromCallback(cb => store.db.get('key1', cb));
+      should(Buffer.from('value1').equals(value)).be.true();
+    });
+
+    it('should pre-write kvps when deleting a quad', async function () {
+      const { store } = this;
+      await store.put(quads[0]);
+      await store.del(quads[0], {
+        preWrite: batch => batch.put('key1', Buffer.from('value1'))
+      });
+      const value = await _.pFromCallback(cb => store.db.get('key1', cb));
+      should(Buffer.from('value1').equals(value)).be.true();
+    });
+
+    it('should pre-write kvps when deleting quads', async function () {
+      const { store } = this;
+      await store.multiPut(quads);
+      await store.multiDel(quads, {
+        preWrite: batch => batch.put('key1', Buffer.from('value1'))
+      });
+      const value = await _.pFromCallback(cb => store.db.get('key1', cb));
+      should(Buffer.from('value1').equals(value)).be.true();
+    });
+
+    it('should pre-write kvps when patching a quad', async function () {
+      const { store } = this;
+      await store.put(quads[0]);
+      await store.patch(quads[0], quads[1], {
+        preWrite: batch => batch.put('key1', Buffer.from('value1'))
+      });
+      const value = await _.pFromCallback(cb => store.db.get('key1', cb));
+      should(Buffer.from('value1').equals(value)).be.true();
+    });
+
+    it('should pre-write kvps when patching quads', async function () {
+      const { store } = this;
+      await store.multiPut([quads[0]]);
+      await store.multiPatch([quads[0]], [quads[1]], {
+        preWrite: batch => batch.put('key1', Buffer.from('value1'))
+      });
+      const value = await _.pFromCallback(cb => store.db.get('key1', cb));
+      should(Buffer.from('value1').equals(value)).be.true();
+    });
+
+  });
+
+};


### PR DESCRIPTION
Here is a simple proposal for the key-value interface discussed in #119 .

On the basis that the creator of the quadstore already has access to the raw backend, this proposal does not try to prevent:
- key collisions with the quad indexes, or
- abuse of the batch by calling `write` or `clear`.

Happy to discuss and add tests/docs when ready.