### PR TITLE
Adding DESCRIBE to Sparql support

### DIFF
--- a/lib/sparql/index.ts
+++ b/lib/sparql/index.ts
@@ -29,6 +29,7 @@ export const sparql = async (store: Quadstore, query: Algebra.Operation|string, 
     case Algebra.types.BGP:
     case Algebra.types.SLICE:
     case Algebra.types.CONSTRUCT:
+    case Algebra.types.DESCRIBE:
       return await comunica.handleQuery(fork, operation);
     case Algebra.types.DELETE_INSERT:
       // TODO: why do we need to cast the operation into its sub-type?
@@ -51,6 +52,7 @@ export const sparqlStream = async (store: Quadstore, query: Algebra.Operation|st
     case Algebra.types.PROJECT:
     case Algebra.types.BGP:
     case Algebra.types.SLICE:
+    case Algebra.types.DESCRIBE:
     case Algebra.types.CONSTRUCT:
     case Algebra.types.ORDER_BY:
       return await comunica.handleQueryStream(fork, operation);

--- a/test/quadstore.prototype.sparql.js
+++ b/test/quadstore.prototype.sparql.js
@@ -7,6 +7,7 @@ module.exports = () => {
     require('./sparql/sparql.select')();
     require('./sparql/sparql.update')();
     require('./sparql/sparql.construct')();
+    require('./sparql/sparql.describe')();
   });
 
 }

--- a/test/sparql/sparql.describe.js
+++ b/test/sparql/sparql.describe.js
@@ -1,0 +1,98 @@
+
+const should = require('should');
+const {ResultType} = require('../../dist/lib/types');
+
+module.exports = () => {
+  describe('DESCRIBE', () => {
+
+    beforeEach(async function () {
+      const { dataFactory, store } = this;
+      const quads = [
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/s'),
+          dataFactory.namedNode('http://ex.com/p'),
+          dataFactory.namedNode('http://ex.com/o'),
+          dataFactory.namedNode('http://ex.com/g')
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/s'),
+          dataFactory.namedNode('http://ex.com/p2'),
+          dataFactory.namedNode('http://ex.com/o2'),
+          dataFactory.namedNode('http://ex.com/g2')
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/s2'),
+          dataFactory.namedNode('http://ex.com/p2'),
+          dataFactory.namedNode('http://ex.com/o'),
+          dataFactory.namedNode('http://ex.com/g')
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/s2'),
+          dataFactory.namedNode('http://ex.com/p'),
+          dataFactory.namedNode('http://ex.com/o2'),
+          dataFactory.namedNode('http://ex.com/g')
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/s2'),
+          dataFactory.namedNode('http://ex.com/p2'),
+          dataFactory.namedNode('http://ex.com/o2'),
+          dataFactory.namedNode('http://ex.com/g2')
+        ),
+      ];
+      await store.multiPut(quads);
+    });
+
+    it('should describe an IRI', async function () {
+      const { dataFactory, store } = this;
+      const result = await store.sparql(`
+        DESCRIBE <http://ex.com/s>
+      `);
+      should(result.type).equal(ResultType.QUADS);
+      should(result.items).be.equalToQuadArray(
+        [
+          dataFactory.quad(
+            dataFactory.namedNode('http://ex.com/s'),
+            dataFactory.namedNode('http://ex.com/p'),
+            dataFactory.namedNode('http://ex.com/o'),
+            dataFactory.defaultGraph(),
+          ),
+          dataFactory.quad(
+            dataFactory.namedNode('http://ex.com/s'),
+            dataFactory.namedNode('http://ex.com/p2'),
+            dataFactory.namedNode('http://ex.com/o2'),
+            dataFactory.defaultGraph(),
+          ),
+        ],
+        store,
+      );
+    });
+
+    it('should describe with a single pattern', async function () {
+      const { dataFactory, store } = this;
+      const result = await store.sparql(`
+        DESCRIBE ?s
+        WHERE { ?s <http://ex.com/p> <http://ex.com/o>. }
+      `);
+      should(result.type).equal(ResultType.QUADS);
+      should(result.items).be.equalToQuadArray(
+        [
+          dataFactory.quad(
+            dataFactory.namedNode('http://ex.com/s'),
+            dataFactory.namedNode('http://ex.com/p'),
+            dataFactory.namedNode('http://ex.com/o'),
+            dataFactory.defaultGraph(),
+          ),
+          dataFactory.quad(
+            dataFactory.namedNode('http://ex.com/s'),
+            dataFactory.namedNode('http://ex.com/p2'),
+            dataFactory.namedNode('http://ex.com/o2'),
+            dataFactory.defaultGraph(),
+          ),
+        ],
+        store,
+      );
+    });
+
+  });
+}
+


### PR DESCRIPTION
Enables the use of Describe queries, which list all [subject triples by default in Comunica](https://github.com/comunica/comunica/blob/master/packages/actor-query-operation-describe-subject/lib/ActorQueryOperationDescribeSubject.ts).