### PR TITLE
AsyncIterator _end race condition workaround

### DIFF
--- a/lib/get/leveliterator.ts
+++ b/lib/get/leveliterator.ts
@@ -56,13 +56,15 @@ export class LevelIterator extends BufferedIterator<Quad> {
 
 
   protected _end(destroy?: boolean) {
-    super._end(destroy);
-    if (!destroy) {
-      this.level.end((endErr?: Error) => {
-        if (endErr) {
-          this.emit('error', endErr);
-        }
-      });
+    if (!this.ended) {
+      super._end(destroy);
+      if (!destroy) {
+        this.level.end((endErr?: Error) => {
+          if (endErr) {
+            this.emit('error', endErr);
+          }
+        });
+      }
     }
   }
 


### PR DESCRIPTION
This is a workaround for a race condition in AsyncIterator, which arises during my unit tests, in which `_end` is called on the `LevelIterator` twice, asynchronously from:
- [asynciterator.ts#L949](https://github.com/RubenVerborgh/AsyncIterator/blob/26e042ab7791e8e6a75fe244a68d38c772564a67/asynciterator.ts#L949)
- [asynciterator.ts#L824](https://github.com/RubenVerborgh/AsyncIterator/blob/26e042ab7791e8e6a75fe244a68d38c772564a67/asynciterator.ts#L824)

The outcome in node-quadstore is that the LevelDown `AbstractIterator` is ended twice, which throws the second time.

I have yet to reproduce this problem either in node-quadstore or in base AsyncIterator.

cc @RubenVerborgh, just in case the cause is obvious.