### PR TITLE
SPARQL join tests & fixes

### DIFF
--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,9 +1,10 @@
-import {TSReadable, TermName} from '../types';
+import {TSReadable, TermName, Pattern} from '../types';
 import {EventEmitter} from 'events';
 import {nanoid} from './nanoid.js';
 import {TransformIterator} from 'asynciterator';
 import {flatMap} from './flatmap.js';
 import {pReduce} from './p-reduce';
+import {Quad, Term} from 'rdf-js';
 
 export const termNames: TermName[] = [
   TermName.SUBJECT,
@@ -45,6 +46,27 @@ export const defaultIndexes: TermName[][] = [
   [TermName.PREDICATE, TermName.OBJECT, TermName.GRAPH, TermName.SUBJECT],
   [TermName.GRAPH, TermName.PREDICATE, TermName.OBJECT, TermName.SUBJECT],
 ];
+
+export const asPattern = (subject?: Term, predicate?: Term, object?: Term, graph?: Term): Pattern | undefined => {
+  if ((!subject || canBePatternPos(TermName.SUBJECT, subject)) &&
+    (!predicate || canBePatternPos(TermName.PREDICATE, predicate)) &&
+    (!object || canBePatternPos(TermName.OBJECT, object)) &&
+    (!graph || canBePatternPos(TermName.GRAPH, graph))) {
+    return { subject, predicate, object, graph };
+  }
+}
+
+export const canBePatternPos = <P extends TermName>(pos: P, term: Term): term is Quad[P] => {
+  // Subjects and Predicate don't allow literals
+  if ((pos == 'subject' || pos == 'predicate') && term.termType == 'Literal') {
+    return false;
+  }
+  // Predicates don't allow blank nodes
+  if (pos == 'predicate' && term.termType == 'BlankNode') {
+    return false;
+  }
+  return true;
+}
 
 export { nanoid };
 

--- a/test/sparql/sparql.select.join.js
+++ b/test/sparql/sparql.select.join.js
@@ -1,0 +1,85 @@
+
+const _ = require('../../dist/lib/utils');
+const should = require('should');
+const {ResultType} = require('../../dist/lib/types');
+const xsd = require('../../dist/lib/serialization/xsd');
+
+module.exports = () => {
+  describe('join queries', () => {
+
+    beforeEach(async function () {
+      const { dataFactory, store } = this;
+      const quads = [
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/bob'),
+          dataFactory.namedNode('http://ex.com/greeting'),
+          dataFactory.literal('hello'),
+          dataFactory.defaultGraph(),
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/bob'),
+          dataFactory.namedNode('http://ex.com/knows'),
+          dataFactory.namedNode('http://ex.com/alice'),
+          dataFactory.defaultGraph()
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/bob'),
+          dataFactory.namedNode('http://ex.com/age'),
+          dataFactory.literal('40', xsd.integer),
+          dataFactory.defaultGraph()
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/alice'),
+          dataFactory.namedNode('http://ex.com/greeting'),
+          dataFactory.literal('hi'),
+          dataFactory.defaultGraph()
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/alice'),
+          dataFactory.namedNode('http://ex.com/knows'),
+          dataFactory.namedNode('http://ex.com/jacopo'),
+          dataFactory.defaultGraph()
+        ),
+        dataFactory.quad(
+          dataFactory.namedNode('http://ex.com/jacopo'),
+          dataFactory.namedNode('http://ex.com/greeting'),
+          dataFactory.literal('ciao'),
+          dataFactory.defaultGraph()
+        ),
+      ];
+      await store.multiPut(quads);
+    });
+
+    it('should join quad patterns', async function () {
+      const {type, items} = await this.store.sparql(`
+        SELECT * {
+          ?s <http://ex.com/knows> ?s2 .
+          ?s2 <http://ex.com/greeting> "hi"
+        }
+      `);
+      should(type).equal(ResultType.BINDINGS);
+      should(items).have.length(1);
+      should(items[0]).have.property('?s');
+      should(items[0]['?s']).have.property('value');
+      should(items[0]['?s']['value']).equal('http://ex.com/bob');
+    });
+
+    it.skip('should join quad patterns with numeric candidate', async function () {
+      // `?s ?p ?s2` can generate a candidate where s2 is numeric
+      // With bottom-up evaluation, this can lead to using the number as a subject
+      const {type, items} = await this.store.sparql(`
+        SELECT * {
+          ?s2 <http://ex.com/greeting> "hi" .
+          ?s ?p ?s2
+        }
+      `);
+      should(type).equal(ResultType.BINDINGS);
+      should(items).have.length(1);
+      should(items[0]).have.property('?s');
+      should(items[0]['?s']).have.property('value');
+      should(items[0]['?s']['value']).equal('http://ex.com/bob');
+    });
+
+  });
+
+};

--- a/test/sparql/sparql.select.js
+++ b/test/sparql/sparql.select.js
@@ -6,5 +6,6 @@ module.exports = () => {
     require('./sparql.select.filters')();
     require('./sparql.select.literals')();
     require('./sparql.select.offsetlimit')();
+    require('./sparql.select.join')();
   });
 };


### PR DESCRIPTION
Trying to track down some issues with SPARQL joins. There are two problems; I have only fixed one. See `test/sparql/sparql.select.join.js`:

1. Doing a basic join with two quad patterns (`should join quad patterns`) passes its test **only in MemDOWN**. I have scratched my head about why this might be but to no avail. @jacoscaz it would be great if you could have a quick look.
1. Doing a join where some of the candidate matches considered during the query have a literal in the Subject position was causing an Error to be thrown inside quadstore. I have fixed this by checking for Term Types in unexpected positions. In doing so I noted that the `match` API in quadstore is more restrictive than that in the RDFJS `Store` API. It appears that Comunica relies upon the looser definition taking Terms for all positions.